### PR TITLE
Add feature to run this tool in alpine image, size is only 20MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang AS builder
+WORKDIR $GOPATH
+RUN go get -u github.com/P3GLEG/Whaler
+WORKDIR $GOPATH/src/github.com/P3GLEG/Whaler
+RUN go build .
+RUN cp Whaler /root/Whaler
+
+FROM debian
+WORKDIR /root/
+COPY --from=builder /root/Whaler .
+ENTRYPOINT ["./Whaler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM golang AS builder
 WORKDIR $GOPATH
 RUN go get -u github.com/P3GLEG/Whaler
 WORKDIR $GOPATH/src/github.com/P3GLEG/Whaler
-RUN go build .
+RUN export CGO_ENABLED=0 && go build .
 RUN cp Whaler /root/Whaler
 
-FROM debian
+FROM alpine
 WORKDIR /root/
 COPY --from=builder /root/Whaler .
 ENTRYPOINT ["./Whaler"]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ You can read more about this on my blog [Here](https://samaritan.ai/blog/reversi
 
 ### How to run it
 
-This image has been pushed to `alpine/dfimage`
+This tool has been pushed to docker image `alpine/dfimage`, the easiest way is to run the tool in docker container:
 
 ```
 alias dfimage="docker run -v /var/run/docker.sock:/var/run/docker.sock --rm alpine/dfimage"
 dfimage -sV=1.36 nginx:latest
 ```
+
+This tool will pull docker image automatically. Parameter `-sV=1.36` is not always required.
 
 ### How to build it
 Git clone the project into your $GOPATH/src directory and perform the following command

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ You can read more about this on my blog [Here](https://samaritan.ai/blog/reversi
 
 ### How to run it
 
-This tool has been pushed to docker image `alpine/dfimage`, the easiest way is to run the tool in docker container:
+The easiest way is to run the tool in docker container:
 
 ```
-alias dfimage="docker run -v /var/run/docker.sock:/var/run/docker.sock --rm alpine/dfimage"
+docker build -t dfimage .
+alias dfimage="docker run -v /var/run/docker.sock:/var/run/docker.sock --rm dfimage"
 dfimage -sV=1.36 nginx:latest
 ```
 
-This tool will pull docker image automatically. Parameter `-sV=1.36` is not always required.
+This tool will pull target docker image automatically. Parameter `-sV=1.36` is not always required.
 
 ### How to build it
 Git clone the project into your $GOPATH/src directory and perform the following command

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Whaler is a Go program which is designed to reverse engineer docker images into 
 ![alt text](https://samaritan.ai/wp-content/uploads/2018/06/Screen-Shot-2018-06-04-at-8.51.22-PM.png "Logo Title Text 1")
 
 You can read more about this on my blog [Here](https://samaritan.ai/blog/reversing-docker-images-into-dockerfiles/)
+
+### How to run it
+
+This image has been pushed to `alpine/dfimage` (currently it still runs in debian)
+
+```
+alias dfimage="docker run -v /var/run/docker.sock:/var/run/docker.sock --rm alpine/dfimage"
+dfimage -sV=1.36 nginx:latest
+```
+
 ### How to build it
 Git clone the project into your $GOPATH/src directory and perform the following command
 ```go

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can read more about this on my blog [Here](https://samaritan.ai/blog/reversi
 
 ### How to run it
 
-This image has been pushed to `alpine/dfimage` (currently it still runs in debian)
+This image has been pushed to `alpine/dfimage`
 
 ```
 alias dfimage="docker run -v /var/run/docker.sock:/var/run/docker.sock --rm alpine/dfimage"


### PR DESCRIPTION
Hi 

This PR added the `Dockerfile` that you can run it in docker container, the easiest way to run the tool and its size is very small

```
dfimage                                   latest              21f37a226b87        15 minutes ago      20.3MB
```

I have pushed to https://hub.docker.com/repository/docker/alpine/dfimage

Maybe you can do the same to push to hub.docker.com with your own account.