### PR TITLE
Modified dockerfile to build with local files + filename fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM golang:1.14.4 AS builder
-WORKDIR $GOPATH
-RUN go get -u github.com/P3GLEG/Whaler
-WORKDIR $GOPATH/src/github.com/P3GLEG/Whaler
+ADD ./ /root/whaler_build
+WORKDIR /root/whaler_build
 RUN export CGO_ENABLED=0 && go build .
-RUN cp Whaler /root/Whaler
+RUN cp whaler /root/whaler
 
 FROM alpine:3.12.0
 WORKDIR /root/
-COPY --from=builder /root/Whaler .
-ENTRYPOINT ["./Whaler"]
+COPY --from=builder /root/whaler .
+ENTRYPOINT ["./whaler"]


### PR DESCRIPTION
Modified the dockerfile so it builds what's currently checked out rather than pulling from public. The go command builds into the `whaler` directory, but the second stage was trying to copy the `Whaler` directory. Additionally the built binary is `whaler` but the entrypoint was `Whaler`.